### PR TITLE
Case-sensitive matching #2

### DIFF
--- a/src/FuzzyCompletions.jl
+++ b/src/FuzzyCompletions.jl
@@ -103,7 +103,17 @@ completion_text(c::DictCompletion) = c.key
 
 const Completions = Tuple{Vector{Completion}, UnitRange{Int64}, Bool}
 
+const CompleteAlways = Union{
+    PathCompletion,
+    PackageCompletion,
+    PropertyCompletion,
+    FieldCompletion,
+    BslashCompletion,
+    DictCompletion,
+}
+
 score(c::Completion) = c.score
+score(c::CompleteAlways) = max(0.0, c.score)
 score(c::MethodCompletion) = 0.0
 score(c::ShellCompletion) = 0.0
 

--- a/src/FuzzyCompletions.jl
+++ b/src/FuzzyCompletions.jl
@@ -9,7 +9,13 @@ using Base.Meta
 using Base: propertynames, something
 using REPL
 
-fuzzyscore(needle, haystack) = REPL.fuzzyscore(string(needle), string(haystack))
+# subtracting a small term proportional to levenshtein distance allows for case-sensitive matching
+# without affecting other behaviours
+const DISCOUNT_COEF_LEVENSTEIN = 1e-4
+
+fuzzyscore(needle::String, haystack::String) =
+    REPL.fuzzyscore(needle, haystack) - DISCOUNT_COEF_LEVENSTEIN * REPL.levenshtein(needle, haystack)
+fuzzyscore(needle, haystack) = fuzzyscore(string(needle), string(haystack))
 
 abstract type Completion end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,3 +84,9 @@ let m = Core.eval(@__MODULE__, :(
     @test ":a" == comp("d[:ad", m) # not empty
 end
 end
+
+@testset "Case Sensitivity" begin
+@test comp("nothing") == "nothing"
+@test comp("Nothing") == "Nothing"
+@test comp("Mis") == "Missing"
+end


### PR DESCRIPTION
This adjusts scoring function `fuzzyscore` by subtracting a small multiple of Levenshtein distance (from `REPL` module). The reason for introducing coefficient rather than making full adjustment (as is done in `REPL.fuzzysort`) is to have sensible completions for short prefixes.

I have not tested the change within Atom editor, since I am not sure how to make downstream packages use modified version of the package. But testset and my repl experiments suggest this should work fine.