### PR TITLE
Also complete symbols when completing keyword arguments

### DIFF
--- a/src/FuzzyCompletions.jl
+++ b/src/FuzzyCompletions.jl
@@ -437,8 +437,12 @@ function complete_keyword_argument(partial, last_idx, context_module)
     end
 
     suggestions = Completion[KeywordArgumentCompletion(kwarg, partial) for kwarg in kwargs]
-    append!(suggestions,
-            transform_to_fuzzy_completion.(REPL.REPLCompletions.complete_symbol(last_word, (mod,x)->true, context_module)))
+    repl_completions = @static if VERSION ≥ v"1.10.0-DEV.981"
+        REPL.REPLCompletions.complete_symbol(nothing, last_word, Returns(true), context_module)
+    else
+        REPL.REPLCompletions.complete_symbol(last_word, (mod,x)->true, context_module)
+    end
+    append!(suggestions, transform_to_fuzzy_completion.(repl_completions))
 
     return sort!(suggestions, by=completion_text), wordrange
 end

--- a/src/FuzzyCompletions.jl
+++ b/src/FuzzyCompletions.jl
@@ -437,7 +437,8 @@ function complete_keyword_argument(partial, last_idx, context_module)
     end
 
     suggestions = Completion[KeywordArgumentCompletion(kwarg, partial) for kwarg in kwargs]
-    # append!(suggestions, complete_symbol(last_word, Returns(true), context_module))
+    append!(suggestions,
+            transform_to_fuzzy_completion.(REPL.REPLCompletions.complete_symbol(last_word, (mod,x)->true, context_module)))
 
     return sort!(suggestions, by=completion_text), wordrange
 end
@@ -460,6 +461,8 @@ function transform_to_fuzzy_completion(@nospecialize c)
         return TextCompletion(c.text)
     elseif @static VERSION ≥ v"1.9.0-DEV.1034" && isa(c, REPL.REPLCompletions.KeywordArgumentCompletion)
         return KeywordArgumentCompletion(c.kwarg)
+    elseif isa(c, REPL.REPLCompletions.ModuleCompletion)
+        return ModuleCompletion(c.parent, c.mod)
     else
         throw("FuzzyCompletions.jl not synced with REPL.REPLCompletions")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,6 +98,12 @@ end
     @test comp("Mis") == "Missing"
 end
 
+@testset "Keyword Argument Completion" begin
+    @test comp("sin(sin") == "sin"
+    @test comp("sum(x; dim") == "dims="
+    @test comp("sum(x, dim") == "dims="
+end
+
 @testset "inferrability" begin
     @inferred FuzzyCompletions.completions("foo", lastindex("foo"), @__MODULE__)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,7 +98,7 @@ end
     @test comp("Mis") == "Missing"
 end
 
-@testset "Keyword Argument Completion" begin
+VERSION > v"1.9" && @testset "Keyword Argument Completion" begin
     @test comp("sin(sin") == "sin"
     @test comp("sum(x; dim") == "dims="
     @test comp("sum(x, dim") == "dims="


### PR DESCRIPTION
The commented line had the effect of disabling symbol completions for queries like `sin(sin` (see https://github.com/fonsp/Pluto.jl/issues/2629).

I added with a non-fuzzy completion from the REPLCompletions module to improve the results in this case. I am very much open to other more optimal solutions.